### PR TITLE
Stop using unstable intrinsics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 #[macro_use]
 extern crate nom;
 use nom::{IResult,ErrorKind};
-use std::intrinsics::copy_nonoverlapping;
+use std::ptr::copy_nonoverlapping;
 use std::mem::transmute;
 
 /// Binary Packet Protocols


### PR DESCRIPTION
copy_nonoverlapping is an intrinsic that was accidentally stabilized. It will be made unstable again in https://github.com/rust-lang/rust/pull/57997.